### PR TITLE
Update hive-wasm and all example project Runnables

### DIFF
--- a/example-project/Directive.yaml
+++ b/example-project/Directive.yaml
@@ -15,12 +15,12 @@ handlers:
           - "url: modify-url"
           - "logme: hello"
   - type: request
-    resource: /set/*key
+    resource: /set/:key
     method: POST
     steps:
       - fn: cache-set
   - type: request
-    resource: /get/*key
+    resource: /get/:key
     method: GET
     steps:
       - fn: cache-get

--- a/example-project/cache-get/.runnable.yaml
+++ b/example-project/cache-get/.runnable.yaml
@@ -1,4 +1,4 @@
 name: cache-get
 namespace: default
 lang: rust
-apiVersion: 0.2.5
+apiVersion: 0.4.0

--- a/example-project/cache-get/Cargo.lock
+++ b/example-project/cache-get/Cargo.lock
@@ -76,9 +76,9 @@ checksum = "01c1c2ededd95f93b1d65e7f8b5b17670e926bf9cbb55f8b91b26b0bd40d3259"
 
 [[package]]
 name = "suborbital"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63fa0507cf400ec0b5b23dcfa1b286c9d7ac4a331131654b54e5117974e8aa5d"
+checksum = "eef06bf46ad2f5926bbd6edd655a89066706dba840d31ea0c9caf69f3b2a3f6d"
 dependencies = [
  "serde",
  "serde_json",

--- a/example-project/cache-get/Cargo.toml
+++ b/example-project/cache-get/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-suborbital = '0.3.0'
+suborbital = '0.4.0'

--- a/example-project/cache-get/src/lib.rs
+++ b/example-project/cache-get/src/lib.rs
@@ -1,18 +1,17 @@
 use suborbital::runnable;
-use suborbital::request;
+use suborbital::req;
 use suborbital::cache;
 use suborbital::log;
 
 struct CacheGet{}
 
 impl runnable::Runnable for CacheGet {
-    fn run(&self, input: Vec<u8>) -> Option<Vec<u8>> {
-        let req = request::from_json(input).unwrap();
+    fn run(&self, _: Vec<u8>) -> Option<Vec<u8>> {
+        let key = req::url_param("key");
 
-        let key: &str = req.url.split('/').last().unwrap();
         log::info(format!("getting cache value {}", key).as_str());
 
-        let val = cache::get(key).unwrap_or_default();
+        let val = cache::get(key.as_str()).unwrap_or_default();
     
         Some(val)
     }

--- a/example-project/cache-set/.runnable.yaml
+++ b/example-project/cache-set/.runnable.yaml
@@ -1,4 +1,4 @@
 name: cache-set
 namespace: default
 lang: rust
-apiVersion: 0.2.5
+apiVersion: 0.4.0

--- a/example-project/cache-set/Cargo.lock
+++ b/example-project/cache-set/Cargo.lock
@@ -76,9 +76,9 @@ checksum = "01c1c2ededd95f93b1d65e7f8b5b17670e926bf9cbb55f8b91b26b0bd40d3259"
 
 [[package]]
 name = "suborbital"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63fa0507cf400ec0b5b23dcfa1b286c9d7ac4a331131654b54e5117974e8aa5d"
+checksum = "eef06bf46ad2f5926bbd6edd655a89066706dba840d31ea0c9caf69f3b2a3f6d"
 dependencies = [
  "serde",
  "serde_json",

--- a/example-project/cache-set/Cargo.toml
+++ b/example-project/cache-set/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-suborbital = '0.3.0'
+suborbital = '0.4.0'

--- a/example-project/cache-set/src/lib.rs
+++ b/example-project/cache-set/src/lib.rs
@@ -1,18 +1,17 @@
 use suborbital::runnable;
-use suborbital::request;
+use suborbital::req;
 use suborbital::cache;
 use suborbital::log;
 
 struct CacheSet{}
 
 impl runnable::Runnable for CacheSet {
-    fn run(&self, input: Vec<u8>) -> Option<Vec<u8>> {
-        let req = request::from_json(input).unwrap();
+    fn run(&self, _: Vec<u8>) -> Option<Vec<u8>> {
 
-        let key: &str = req.url.split('/').last().unwrap();
+        let key = req::url_param("key");
         log::info(format!("setting cache value {}", key).as_str());
 
-        cache::set(key, Vec::from(req.body), 0);
+        cache::set(key.as_str(), Vec::from(req::body_raw()), 0);
 
         Some(String::from("ok").as_bytes().to_vec())
     }

--- a/example-project/fetch-test/Cargo.lock
+++ b/example-project/fetch-test/Cargo.lock
@@ -76,9 +76,9 @@ checksum = "01c1c2ededd95f93b1d65e7f8b5b17670e926bf9cbb55f8b91b26b0bd40d3259"
 
 [[package]]
 name = "suborbital"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63fa0507cf400ec0b5b23dcfa1b286c9d7ac4a331131654b54e5117974e8aa5d"
+checksum = "eef06bf46ad2f5926bbd6edd655a89066706dba840d31ea0c9caf69f3b2a3f6d"
 dependencies = [
  "serde",
  "serde_json",

--- a/example-project/fetch-test/Cargo.toml
+++ b/example-project/fetch-test/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-suborbital = '0.3.0'
+suborbital = '0.4.0'

--- a/example-project/fetch-test/src/lib.rs
+++ b/example-project/fetch-test/src/lib.rs
@@ -1,23 +1,19 @@
 use suborbital::runnable;
-use suborbital::request;
-use suborbital::net;
+use suborbital::req;
+use suborbital::http;
 use suborbital::log;
 
 struct FetchTest{}
 
 impl runnable::Runnable for FetchTest {
-    fn run(&self, input: Vec<u8>) -> Option<Vec<u8>> {
-        let req = match request::from_json(input) {
-            Some(r) => r,
-            None => return Some(String::from("failed").as_bytes().to_vec())
-        };
+    fn run(&self, _: Vec<u8>) -> Option<Vec<u8>> {
 
-        let msg = req.state["logme"].as_str().unwrap();
-        log::info(msg);
+        let msg = req::state("logme");
+        log::info(msg.as_str());
 
-        let url = req.state["url"].as_str().unwrap();
+        let url = req::state("url");
 
-        let data = net::get(url); 
+        let data = http::get(url.as_str()); 
 
         Some(data)
     }

--- a/example-project/helloworld-rs/.runnable.yml
+++ b/example-project/helloworld-rs/.runnable.yml
@@ -1,4 +1,4 @@
 name: helloworld-rs
 namespace: default
 lang: rust
-apiVersion: 0.2.5
+apiVersion: 0.4.0

--- a/example-project/helloworld-rs/Cargo.lock
+++ b/example-project/helloworld-rs/Cargo.lock
@@ -76,9 +76,9 @@ checksum = "01c1c2ededd95f93b1d65e7f8b5b17670e926bf9cbb55f8b91b26b0bd40d3259"
 
 [[package]]
 name = "suborbital"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63fa0507cf400ec0b5b23dcfa1b286c9d7ac4a331131654b54e5117974e8aa5d"
+checksum = "eef06bf46ad2f5926bbd6edd655a89066706dba840d31ea0c9caf69f3b2a3f6d"
 dependencies = [
  "serde",
  "serde_json",

--- a/example-project/helloworld-rs/Cargo.toml
+++ b/example-project/helloworld-rs/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-suborbital = '0.3.0'
+suborbital = '0.4.0'

--- a/example-project/helloworld-rs/src/lib.rs
+++ b/example-project/helloworld-rs/src/lib.rs
@@ -1,16 +1,14 @@
 use suborbital::runnable;
-use suborbital::request;
+use suborbital::req;
+use suborbital::util;
 
 struct HelloworldRs{}
 
 impl runnable::Runnable for HelloworldRs {
-    fn run(&self, input: Vec<u8>) -> Option<Vec<u8>> {
-        let req = match request::from_json(input) {
-            Some(r) => r,
-            None => return Some(String::from("failed").as_bytes().to_vec())
-        };
-    
-        Some(String::from(format!("hello {}", req.body)).as_bytes().to_vec())
+    fn run(&self, _: Vec<u8>) -> Option<Vec<u8>> {
+        let msg = format!("hello {}", util::to_string(req::body_raw()));
+
+        Some(util::to_vec(String::from(msg)))
     }
 }
 

--- a/example-project/modify-url/.runnable.yml
+++ b/example-project/modify-url/.runnable.yml
@@ -1,4 +1,4 @@
 name: modify-url
 namespace: default
 lang: rust
-apiVersion: 0.2.5
+apiVersion: 0.4.0

--- a/example-project/modify-url/Cargo.lock
+++ b/example-project/modify-url/Cargo.lock
@@ -76,9 +76,9 @@ checksum = "01c1c2ededd95f93b1d65e7f8b5b17670e926bf9cbb55f8b91b26b0bd40d3259"
 
 [[package]]
 name = "suborbital"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63fa0507cf400ec0b5b23dcfa1b286c9d7ac4a331131654b54e5117974e8aa5d"
+checksum = "eef06bf46ad2f5926bbd6edd655a89066706dba840d31ea0c9caf69f3b2a3f6d"
 dependencies = [
  "serde",
  "serde_json",

--- a/example-project/modify-url/Cargo.toml
+++ b/example-project/modify-url/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-suborbital = '0.3.0'
+suborbital = '0.4.0'

--- a/example-project/modify-url/src/lib.rs
+++ b/example-project/modify-url/src/lib.rs
@@ -1,16 +1,14 @@
 use suborbital::runnable;
-use suborbital::request;
+use suborbital::req;
+use suborbital::util;
 
 struct ModifyUrl{}
 
 impl runnable::Runnable for ModifyUrl {
-    fn run(&self, input: Vec<u8>) -> Option<Vec<u8>> {
-        let req = match request::from_json(input) {
-            Some(r) => r,
-            None => return Some(String::from("failed").as_bytes().to_vec())
-        };
+    fn run(&self, _: Vec<u8>) -> Option<Vec<u8>> {
+        let body_str = util::to_string(req::body_raw());
 
-        let modified = format!("{}/suborbital", req.body.as_str());
+        let modified = format!("{}/suborbital", body_str.as_str());
         Some(modified.as_bytes().to_vec())
     }
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/suborbital/grav v0.3.0
 	github.com/suborbital/hive v0.2.0
-	github.com/suborbital/hive-wasm v0.3.0
+	github.com/suborbital/hive-wasm v0.4.0
 	github.com/suborbital/vektor v0.2.2
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
 	golang.org/x/mod v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -200,6 +200,8 @@ github.com/suborbital/hive-wasm v0.2.6 h1:wBvimdaNDFu5fja35uzAi6yXKba4DHNVV0OtaQ
 github.com/suborbital/hive-wasm v0.2.6/go.mod h1:D3xySADEKHXXaySSUCdM4eqxnIb44X78JQb7OFh+XK8=
 github.com/suborbital/hive-wasm v0.3.0 h1:JPgfB6XJbC32hrQJgvlOrKPYONXkvm/hpF2004obtKw=
 github.com/suborbital/hive-wasm v0.3.0/go.mod h1:sXvTgWgD7j12e7VeHUuPgUwWN+hnLMz76j65zHS/dFE=
+github.com/suborbital/hive-wasm v0.4.0 h1:/f8bkllyId6Uf2xWYQVEuyRf3KrtpObHr2QrUYRiMVA=
+github.com/suborbital/hive-wasm v0.4.0/go.mod h1:sXvTgWgD7j12e7VeHUuPgUwWN+hnLMz76j65zHS/dFE=
 github.com/suborbital/vektor v0.1.1/go.mod h1:tJ4gA2P8NWC4Pdu0TgpSBWZHuZ1Qhp+r5RlsqyIqdyw=
 github.com/suborbital/vektor v0.1.3/go.mod h1:tJ4gA2P8NWC4Pdu0TgpSBWZHuZ1Qhp+r5RlsqyIqdyw=
 github.com/suborbital/vektor v0.2.2 h1:x3yit9RMXcP8LirkKb1f/psNev/G/iTIHo6eL/f1OBI=

--- a/release/version.go
+++ b/release/version.go
@@ -1,4 +1,4 @@
 package release
 
 // AtmoDotVersion represents the dot version for atmo
-var AtmoDotVersion = "0.0.2"
+var AtmoDotVersion = "0.0.4"

--- a/vendor/github.com/suborbital/hive-wasm/request/request.go
+++ b/vendor/github.com/suborbital/hive-wasm/request/request.go
@@ -1,0 +1,102 @@
+package request
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/suborbital/vektor/vk"
+)
+
+// CoordinatedRequest represents a request whose fulfillment can be coordinated across multiple hosts
+// and is serializable to facilitate interoperation with Wasm Runnables and transmissible over the wire
+type CoordinatedRequest struct {
+	Method  string            `json:"method"`
+	URL     string            `json:"url"`
+	ID      string            `json:"request_id"`
+	Body    []byte            `json:"body"`
+	Headers map[string]string `json:"headers"`
+	Params  map[string]string `json:"params"`
+	State   map[string][]byte `json:"state"`
+
+	bodyValues map[string]interface{} `json:"-"`
+}
+
+// FromVKRequest creates a CoordinatedRequest from an http.Request
+func FromVKRequest(r *http.Request, ctx *vk.Ctx) (*CoordinatedRequest, error) {
+	reqBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, vk.E(http.StatusInternalServerError, "failed to read request body")
+	}
+
+	defer r.Body.Close()
+
+	flatHeaders := map[string]string{}
+	for k, v := range r.Header {
+		flatHeaders[k] = v[0]
+	}
+
+	flatParams := map[string]string{}
+	for _, p := range ctx.Params {
+		flatParams[p.Key] = p.Value
+	}
+
+	req := &CoordinatedRequest{
+		Method:  r.Method,
+		URL:     r.URL.RequestURI(),
+		ID:      ctx.RequestID(),
+		Body:    reqBody,
+		Headers: flatHeaders,
+		Params:  flatParams,
+		State:   map[string][]byte{},
+	}
+
+	return req, nil
+}
+
+// BodyField returns a field from the request body as a string
+func (c *CoordinatedRequest) BodyField(key string) (string, error) {
+	if c.bodyValues == nil {
+		if len(c.Body) == 0 {
+			return "", nil
+		}
+
+		vals := map[string]interface{}{}
+
+		if err := json.Unmarshal(c.Body, &vals); err != nil {
+			return "", errors.Wrap(err, "failed to Unmarshal request body")
+		}
+
+		// cache the parsed body
+		c.bodyValues = vals
+	}
+
+	interfaceVal, ok := c.bodyValues[key]
+	if !ok {
+		return "", nil
+	}
+
+	stringVal, ok := interfaceVal.(string)
+	if !ok {
+		return "", fmt.Errorf("request body value %s is not a string", key)
+	}
+
+	return stringVal, nil
+}
+
+// FromJSON unmarshalls a CoordinatedRequest from JSON
+func FromJSON(jsonBytes []byte) (*CoordinatedRequest, error) {
+	req := CoordinatedRequest{}
+	if err := json.Unmarshal(jsonBytes, &req); err != nil {
+		return nil, errors.Wrap(err, "failed to Unmarshal request")
+	}
+
+	return &req, nil
+}
+
+// ToJSON returns a JSON representation of a CoordinatedRequest
+func (c *CoordinatedRequest) ToJSON() ([]byte, error) {
+	return json.Marshal(c)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -21,10 +21,11 @@ github.com/suborbital/grav/grav
 # github.com/suborbital/hive v0.2.0
 ## explicit
 github.com/suborbital/hive/hive
-# github.com/suborbital/hive-wasm v0.3.0
+# github.com/suborbital/hive-wasm v0.4.0
 ## explicit
 github.com/suborbital/hive-wasm/bundle
 github.com/suborbital/hive-wasm/directive
+github.com/suborbital/hive-wasm/request
 github.com/suborbital/hive-wasm/wasm
 # github.com/suborbital/vektor v0.2.2
 ## explicit


### PR DESCRIPTION
Atmo now uses hive-wasm v0.4.0 and uses its new CoordinatedRequest type along with the helpers and API version that comes with it.

Example project Runnables have been updated to use API 0.4.0.