### PR TITLE
Add 'wait' ability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ atmo: build
 	ATMO_HTTP_PORT=8080 .bin/atmo $(bundle)
 
 atmo/docker: docker/dev
-	docker run -v ${PWD}/$(dir):/home/atmo -e ATMO_HTTP_PORT=8080 -p 8080:8080 atmo:dev atmo
+	docker run -v ${PWD}/$(dir):/home/atmo -e ATMO_HTTP_PORT=8080 -p 8080:8080 atmo:dev atmo --wait
 
 docker/dev:
 	docker build . -t atmo:dev

--- a/atmo/atmo.go
+++ b/atmo/atmo.go
@@ -1,51 +1,40 @@
 package atmo
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/suborbital/atmo/atmo/coordinator"
 	"github.com/suborbital/atmo/atmo/options"
-	"github.com/suborbital/atmo/atmo/release"
 	"github.com/suborbital/reactr/bundle"
 	"github.com/suborbital/reactr/rwasm"
 	"github.com/suborbital/vektor/vk"
-	"github.com/suborbital/vektor/vlog"
 )
 
 // Atmo is an Atmo server
 type Atmo struct {
 	coordinator *coordinator.Coordinator
-	options     options.Options
+	server      *vk.Server
 
-	server *vk.Server
-}
-
-type atmoInfo struct {
-	AtmoVersion string `json:"atmo_version"`
+	options *options.Options
 }
 
 // New creates a new Atmo instance
-func New() *Atmo {
-	logger := vlog.Default(
-		vlog.AppMeta(atmoInfo{AtmoVersion: release.AtmoDotVersion}),
-		vlog.Level(vlog.LogLevelInfo),
-		vlog.EnvPrefix("ATMO"),
-	)
+func New(opts ...options.Modifier) *Atmo {
+	atmoOpts := options.NewWithModifiers(opts...)
 
-	rwasm.UseLogger(logger)
+	rwasm.UseLogger(atmoOpts.Logger)
 
 	server := vk.New(
 		vk.UseEnvPrefix("ATMO"),
 		vk.UseAppName("Atmo"),
-		vk.UseLogger(logger),
-	)
-
-	opts := options.NewWithModifiers(
-		options.UseLogger(logger),
+		vk.UseLogger(atmoOpts.Logger),
 	)
 
 	a := &Atmo{
-		coordinator: coordinator.New(opts),
+		coordinator: coordinator.New(atmoOpts),
 		server:      server,
+		options:     atmoOpts,
 	}
 
 	return a
@@ -53,12 +42,29 @@ func New() *Atmo {
 
 // Start starts the Atmo server
 func (a *Atmo) Start(bundlePath string) error {
-	bundle, err := bundle.Read(bundlePath)
-	if err != nil {
-		return errors.Wrap(err, "failed to ReadBundle")
+	var bdl *bundle.Bundle
+
+	for {
+		b, err := bundle.Read(bundlePath)
+		if err != nil {
+			// if there was a problem, but the 'wait' option is set,
+			// then try again after a second
+			if a.options.Wait {
+				a.options.Logger.Warn("failed to Read bundle, will try again:", err.Error())
+				time.Sleep(time.Second)
+				continue
+			}
+
+			return errors.Wrap(err, "failed to ReadBundle")
+		}
+
+		a.options.Logger.Info("found bundle at", bundlePath)
+
+		bdl = b
+		break
 	}
 
-	routes := a.coordinator.UseBundle(bundle)
+	routes := a.coordinator.UseBundle(bdl)
 	a.server.AddGroup(routes)
 
 	if err := a.server.Start(); err != nil {

--- a/atmo/options/options.go
+++ b/atmo/options/options.go
@@ -14,6 +14,7 @@ const atmoEnvPrefix = "ATMO"
 type Options struct {
 	Logger       *vlog.Logger `env:"-"`
 	RunSchedules string       `env:"ATMO_RUN_SCHEDULES"`
+	Wait         bool         `env:"ATMO_WAIT"`
 }
 
 // Modifier defines options for Atmo
@@ -35,6 +36,13 @@ func NewWithModifiers(mods ...Modifier) *Options {
 func UseLogger(logger *vlog.Logger) Modifier {
 	return func(opts *Options) {
 		opts.Logger = logger
+	}
+}
+
+// ShouldWait sets wether Atmo should wait for a bundle to become available on disk
+func ShouldWait(wait bool) Modifier {
+	return func(opts *Options) {
+		opts.Wait = wait
 	}
 }
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -19,7 +19,7 @@
 * [Scheduled jobs](usage/schedules.md)
 * [ForEach](usage/foreach.md)
 * [Building a Bundle](usage/building-a-bundle.md)
-* [Running Atmo](usage/running-atmo.md)
+* [Deploying Atmo](usage/deploying-atmo.md)
 
 ## Runnable API
 

--- a/docs/usage/deploying-atmo.md
+++ b/docs/usage/deploying-atmo.md
@@ -6,7 +6,7 @@ Atmo is still in early Beta, and as such should not yet be used for production w
 
 Atmo is distributed as a Docker image: `suborbital/atmo`
 
-To run Atmo, you can either mount your Runnable Bundle as a volume, or build your own container image that embeds it.
+To run Atmo, you can mount your Runnable Bundle as a volume, build your own container image that embeds it, or set Atmo to wait for a bundle to be uploaded.
 
 ## Volume mount
 
@@ -32,9 +32,13 @@ ENTRYPOINT atmo
 
 Building this Dockerfile would result in an image that doesn't need a volume mount.
 
+## Bundle upload
+
+To upload a bundle after launching Atmo, use the `--wait` flag or set the `ATMO_WAIT=true` env var. This will cause Atmo to check the disk once per second until it finds a bundle rather than exiting with an error if no bundle is found. This method allows you to launch Atmo and then upload a bundle seperately by copying it into the running container, as with the [experimental Kubernetes deployment](https://github.com/suborbital/atmo-k8s-helm).
+
 ### HTTPS
 
-To run with HTTPS, replace `ATMO_HTTP_PORT=8080` with `ATMO_DOMAIN=example.com` to enable LetsEncrypt on ports 443 and 8080. You will need to pass the `-p` Docker flag for each.
+To run with HTTPS, replace `ATMO_HTTP_PORT=8080` with `ATMO_DOMAIN=example.com` to enable LetsEncrypt on ports 443 and 80. You will need to pass the `-p` Docker flag for each.
 
 ### Logging
 


### PR DESCRIPTION
This PR allows Atmo to 'wait' for a bundle to exist on disk and startup when it does, rather than erroring out if no bundle exists.

This is to support easier K8s deployments, and can be tried out here: https://github.com/suborbital/atmo-k8s-helm