### PR TITLE
Small improvements to documentation

### DIFF
--- a/docs/usage/building-a-bundle.md
+++ b/docs/usage/building-a-bundle.md
@@ -3,7 +3,7 @@
 To run your Atmo application, we need to create a Runnable Bundle. A Bundle is a `.wasm.zip` file that includes your Directive, along with all of your Runnables compiled to WebAssembly modules. Bundles are built using `subo`. **Note** that you should pass the root of your Atmo project as the first argument:
 
 ```bash
-subo build . --bundle
+subo build .
 ```
 
 The end of this command should read:
@@ -25,4 +25,3 @@ The version of Atmo being run by `subo dev` is dictated by the `atmoVersion` key
 {% endhint %}
 
 Continue on to learn how to operate Atmo in real-world scenarios.
-

--- a/docs/usage/error-handling.md
+++ b/docs/usage/error-handling.md
@@ -1,6 +1,6 @@
 # Error Handling
 
-When building your Atmo app, handling errors returned from Runnables is pretty essential. When a Runnable returns an error, it contains a `code` and a `message`. Using the Directive, you can manage how your application behaves when an error is returned:
+When building your Atmo app, handling errors returned from Runnables is pretty essential. When a Runnable returns an error, it contains a `code` and a `message`. The `code` must be a valid [HTTP response status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status). Using the Directive, you can manage how your application behaves when an error is returned:
 
 {% hint style="info" %}
 The default behaviour for any error is for the handler to return.


### PR DESCRIPTION
## Changes
- Remove usage of defunct `--bundle` flag for `subo build`
- Mention that error codes must be valid HTTP response status codes. This was an issue I encountered which was causing `atmo` to panic when serving invalid codes. Happy to revert this particular change if you think it doesn't warrant mentioning.