### PR TITLE
Headless mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,7 @@ deps:
 mod/replace/reactr:
 	go mod edit -replace github.com/suborbital/reactr=$(HOME)/Workspaces/suborbital/reactr
 
+mod/replace/vektor:
+	go mod edit -replace github.com/suborbital/vektor=$(HOME)/Workspaces/suborbital/vektor
+
 .PHONY: build atmo atmo/docker docker/dev docker/dev/multi docker/publish docker/builder example-project test deps

--- a/atmo/appsource/appsource.go
+++ b/atmo/appsource/appsource.go
@@ -1,9 +1,13 @@
 package appsource
 
 import (
+	"errors"
+
 	"github.com/suborbital/atmo/atmo/options"
 	"github.com/suborbital/atmo/directive"
 )
+
+var ErrRunnableNotFound = errors.New("failed to find requested Runnable")
 
 // Meta describes the metadata for an App
 type Meta struct {
@@ -16,6 +20,11 @@ type AppSource interface {
 	Start(options.Options) error
 	// Runnables returns all of the available Runnables
 	Runnables() []directive.Runnable
+	// FindRunnable directs the AppSource to attempt to find
+	// a particular Runnable and make it available at next
+	// AppSource state sync via a call to Runnables().
+	// ErrRunnableNotFound should be returned if the Runnable cannot be found.
+	FindRunnable(string) error
 	// Handlers returns the handlers for the app
 	Handlers() []directive.Handler
 	// Schedules returns the requested schedules for the app

--- a/atmo/appsource/bundlesource.go
+++ b/atmo/appsource/bundlesource.go
@@ -50,6 +50,23 @@ func (b *BundleSource) Runnables() []directive.Runnable {
 	return b.bundle.Directive.Runnables
 }
 
+// FindRunnable returns a nil error if a Runnable with the
+// provided FQFN can be made available at the next sync,
+// otherwise ErrRunnableNotFound is returned
+func (b *BundleSource) FindRunnable(fqfn string) error {
+	if b.bundle == nil {
+		return ErrRunnableNotFound
+	}
+
+	for _, r := range b.bundle.Directive.Runnables {
+		if r.FQFN == fqfn {
+			return nil
+		}
+	}
+
+	return ErrRunnableNotFound
+}
+
 // Handlers returns the handlers for the app
 func (b *BundleSource) Handlers() []directive.Handler {
 	if b.bundle == nil {

--- a/atmo/appsource/bundlesource.go
+++ b/atmo/appsource/bundlesource.go
@@ -95,7 +95,7 @@ func (b *BundleSource) findBundle() error {
 	for {
 		bdl, err := bundle.Read(b.path)
 		if err != nil {
-			if !b.opts.Wait {
+			if !*b.opts.Wait {
 				return errors.Wrap(err, "failed to Read bundle")
 			}
 

--- a/atmo/appsource/headlessbundlesource.go
+++ b/atmo/appsource/headlessbundlesource.go
@@ -1,0 +1,127 @@
+package appsource
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/suborbital/atmo/atmo/options"
+	"github.com/suborbital/atmo/directive"
+	"github.com/suborbital/atmo/fqfn"
+)
+
+// HeadlessBundleSource is an AppSource backed by a bundle file
+type HeadlessBundleSource struct {
+	path         string
+	opts         options.Options
+	bundlesource *BundleSource
+}
+
+// NewHeadlessBundleSource creates a new HeadlessBundleSource that looks for a bundle at [path]
+func NewHeadlessBundleSource(path string) AppSource {
+	b := &HeadlessBundleSource{
+		path: path,
+		// re-use BundleSource's Directive-finding logic etc
+		bundlesource: NewBundleSource(path).(*BundleSource),
+	}
+
+	return b
+}
+
+// Start initializes the app source
+func (h *HeadlessBundleSource) Start(opts options.Options) error {
+	h.opts = opts
+
+	if err := h.bundlesource.Start(opts); err != nil {
+		return errors.Wrap(err, "failed to bundlesource.Start")
+	}
+
+	return nil
+}
+
+// Runnables returns the Runnables for the app
+func (h *HeadlessBundleSource) Runnables() []directive.Runnable {
+	if h.bundlesource.bundle == nil {
+		return []directive.Runnable{}
+	}
+
+	return h.bundlesource.Runnables()
+}
+
+// FindRunnable returns a nil error if a Runnable with the
+// provided FQFN can be made available at the next sync,
+// otherwise ErrRunnableNotFound is returned
+func (h *HeadlessBundleSource) FindRunnable(fqfn string) error {
+	if h.bundlesource.bundle == nil {
+		return ErrRunnableNotFound
+	}
+
+	for _, r := range h.bundlesource.Runnables() {
+		if r.FQFN == fqfn {
+			return nil
+		}
+	}
+
+	return ErrRunnableNotFound
+}
+
+// Handlers returns the handlers for the app
+func (h *HeadlessBundleSource) Handlers() []directive.Handler {
+	if h.bundlesource.bundle == nil {
+		return []directive.Handler{}
+	}
+
+	handlers := []directive.Handler{}
+
+	// for each Runnable, construct a handler that executes it
+	// based on a POST request to its FQFN URL /identifier/namespace/fn/version
+	for _, runnable := range h.bundlesource.Runnables() {
+		handler := directive.Handler{
+			Input: directive.Input{
+				Type:     directive.InputTypeRequest,
+				Method:   http.MethodPost,
+				Resource: fqfn.Parse(runnable.FQFN).HeadlessURLPath(),
+			},
+			Steps: []directive.Executable{
+				{
+					CallableFn: directive.CallableFn{
+						Fn:   runnable.Name,
+						With: map[string]string{},
+						FQFN: runnable.FQFN,
+					},
+				},
+			},
+		}
+
+		handlers = append(handlers, handler)
+	}
+
+	return handlers
+}
+
+// Schedules returns the schedules for the app
+func (h *HeadlessBundleSource) Schedules() []directive.Schedule {
+	return []directive.Schedule{}
+}
+
+// File returns a requested file
+func (h *HeadlessBundleSource) File(filename string) ([]byte, error) {
+	if h.bundlesource.bundle == nil {
+		return nil, os.ErrNotExist
+	}
+
+	return h.bundlesource.bundle.StaticFile(filename)
+}
+
+func (h *HeadlessBundleSource) Meta() Meta {
+	if h.bundlesource.bundle == nil {
+		return Meta{}
+	}
+
+	m := Meta{
+		Identifier: h.bundlesource.bundle.Directive.Identifier,
+		AppVersion: h.bundlesource.bundle.Directive.AppVersion,
+	}
+
+	return m
+}

--- a/atmo/atmo.go
+++ b/atmo/atmo.go
@@ -28,6 +28,11 @@ func New(opts ...options.Modifier) *Atmo {
 	rwasm.UseLogger(atmoOpts.Logger)
 
 	appSource := appsource.NewBundleSource(atmoOpts.BundlePath)
+	if *atmoOpts.Headless {
+		// the headless appsource ignores the Directive and mounts
+		// each Runnable as its own route (for testing, other purposes)
+		appSource = appsource.NewHeadlessBundleSource(atmoOpts.BundlePath)
+	}
 
 	a := &Atmo{
 		coordinator: coordinator.New(appSource, atmoOpts),

--- a/atmo/atmo.go
+++ b/atmo/atmo.go
@@ -88,7 +88,7 @@ func (a *Atmo) inspectRequest(r http.Request) {
 		}
 
 		if err := a.coordinator.App.FindRunnable(FQFN); err != nil {
-			a.options.Logger.Debug(errors.Wrapf(err, "failed to FindRunnable %s, request will proceed and fail").Error())
+			a.options.Logger.Debug(errors.Wrapf(err, "failed to FindRunnable %s, request will proceed and fail", FQFN).Error())
 			return
 		}
 

--- a/atmo/coordinator/coordinator.go
+++ b/atmo/coordinator/coordinator.go
@@ -111,7 +111,7 @@ func (c *Coordinator) GenerateRouter() *vk.RouteGroup {
 
 		// only actually schedule the job if the env var isn't set (or is set but not 'false')
 		// the job stays mounted on reactr because we could get a request to run it from grav
-		if c.opts.RunSchedules == "true" {
+		if *c.opts.RunSchedules {
 			c.reactr.Schedule(rt.Every(seconds, func() rt.Job {
 				return rt.NewJob(jobName, nil)
 			}))

--- a/atmo/coordinator/coordinator.go
+++ b/atmo/coordinator/coordinator.go
@@ -103,7 +103,6 @@ func (c *Coordinator) SetSchedules() {
 
 		// create basically an fqfn for this schedule (com.suborbital.appname#schedule.dojob@v0.1.0)
 		jobName := fmt.Sprintf("%s#schedule.%s@%s", c.App.Meta().Identifier, s.Name, c.App.Meta().AppVersion)
-		c.log.Debug("adding schedule", jobName)
 
 		c.reactr.Register(jobName, &scheduledRunner{rtFunc})
 
@@ -112,6 +111,8 @@ func (c *Coordinator) SetSchedules() {
 		// only actually schedule the job if the env var isn't set (or is set but not 'false')
 		// the job stays mounted on reactr because we could get a request to run it from grav
 		if *c.opts.RunSchedules {
+			c.log.Debug("adding schedule", jobName)
+
 			c.reactr.Schedule(rt.Every(seconds, func() rt.Job {
 				return rt.NewJob(jobName, nil)
 			}))

--- a/atmo/coordinator/coordinator_appstate.go
+++ b/atmo/coordinator/coordinator_appstate.go
@@ -1,0 +1,34 @@
+package coordinator
+
+import (
+	"github.com/pkg/errors"
+	"github.com/suborbital/atmo/bundle/load"
+)
+
+func (c *Coordinator) SyncAppState() {
+	c.log.Debug("syncing AppSource state")
+
+	// mount all of the Wasm Runnables into the Reactr instance
+	// pass 'false' for registerSimpleName since we'll only ever call
+	// functions by their FQFNs
+	if err := load.Runnables(c.reactr, c.App.Runnables(), c.App.File, false); err != nil {
+		c.log.Error(errors.Wrap(err, "failed to load.Runnables"))
+	}
+
+	// connect a Grav pod to each function
+	for _, fn := range c.App.Runnables() {
+		if fn.FQFN == "" {
+			c.log.ErrorString("fn", fn.Name, "missing calculated FQFN, will not be available")
+			continue
+		}
+
+		// check to see if we're already listening for this function
+		// on the local Reactr instance, and start if need be
+		if _, exists := c.listening.Load(fn.FQFN); !exists {
+			c.log.Debug("adding listener for", fn.FQFN)
+			c.reactr.Listen(c.grav.Connect(), fn.FQFN)
+
+			c.listening.Store(fn.FQFN, true)
+		}
+	}
+}

--- a/atmo/coordinator/sequence.go
+++ b/atmo/coordinator/sequence.go
@@ -199,7 +199,7 @@ func stateJSONForStep(req *request.CoordinatedRequest, step directive.Executable
 }
 
 func desiredState(desired map[string]string, state map[string][]byte) (map[string][]byte, error) {
-	if desired == nil || len(desired) == 0 {
+	if len(desired) == 0 {
 		return state, nil
 	}
 

--- a/atmo/options/options.go
+++ b/atmo/options/options.go
@@ -14,9 +14,9 @@ const atmoEnvPrefix = "ATMO"
 type Options struct {
 	Logger       *vlog.Logger `env:"-"`
 	BundlePath   string       `env:"ATMO_BUNDLE_PATH"`
-	RunSchedules *bool        `env:"ATMO_RUN_SCHEDULES"`
-	Headless     *bool        `env:"ATMO_HEADLESS"`
-	Wait         *bool        `env:"ATMO_WAIT"`
+	RunSchedules *bool        `env:"ATMO_RUN_SCHEDULES,default=true"`
+	Headless     *bool        `env:"ATMO_HEADLESS,default=false"`
+	Wait         *bool        `env:"ATMO_WAIT,default=false"`
 }
 
 // Modifier defines options for Atmo
@@ -80,15 +80,17 @@ func (o *Options) finalize(prefix string) {
 		return
 	}
 
-	o.RunSchedules = envOpts.RunSchedules
+	// set RunSchedules if it was not passed as a flag
+	if o.RunSchedules == nil {
+		if envOpts.RunSchedules != nil {
+			o.RunSchedules = envOpts.RunSchedules
+		}
+	}
 
 	// set Wait if it was not passed as a flag
 	if o.Wait == nil {
 		if envOpts.Wait != nil {
 			o.Wait = envOpts.Wait
-		} else {
-			wait := false
-			o.Wait = &wait
 		}
 	}
 
@@ -96,9 +98,6 @@ func (o *Options) finalize(prefix string) {
 	if o.Headless == nil {
 		if envOpts.Headless != nil {
 			o.Headless = envOpts.Headless
-		} else {
-			headless := false
-			o.Headless = &headless
 		}
 	}
 }

--- a/atmo/options/options.go
+++ b/atmo/options/options.go
@@ -14,15 +14,16 @@ const atmoEnvPrefix = "ATMO"
 type Options struct {
 	Logger       *vlog.Logger `env:"-"`
 	BundlePath   string       `env:"ATMO_BUNDLE_PATH"`
-	RunSchedules string       `env:"ATMO_RUN_SCHEDULES"`
-	Wait         bool         `env:"ATMO_WAIT"`
+	RunSchedules *bool        `env:"ATMO_RUN_SCHEDULES"`
+	Headless     *bool        `env:"ATMO_HEADLESS"`
+	Wait         *bool        `env:"ATMO_WAIT"`
 }
 
 // Modifier defines options for Atmo
 type Modifier func(*Options)
 
 func NewWithModifiers(mods ...Modifier) *Options {
-	opts := defaultOptions()
+	opts := &Options{}
 
 	for _, mod := range mods {
 		mod(opts)
@@ -47,10 +48,23 @@ func UseBundlePath(path string) Modifier {
 	}
 }
 
+// ShouldRunHeadless sets wether Atmo should operate in 'headless' mode
+func ShouldRunHeadless(headless bool) Modifier {
+	return func(opts *Options) {
+		// only set the pointer if the value is true
+		if headless {
+			opts.Headless = &headless
+		}
+	}
+}
+
 // ShouldWait sets wether Atmo should wait for a bundle to become available on disk
 func ShouldWait(wait bool) Modifier {
 	return func(opts *Options) {
-		opts.Wait = wait
+		// only set the pointer if the value is true
+		if wait {
+			opts.Wait = &wait
+		}
 	}
 }
 
@@ -66,15 +80,25 @@ func (o *Options) finalize(prefix string) {
 		return
 	}
 
-	if envOpts.RunSchedules != "" {
-		o.RunSchedules = envOpts.RunSchedules
-	}
-}
+	o.RunSchedules = envOpts.RunSchedules
 
-func defaultOptions() *Options {
-	o := &Options{
-		RunSchedules: "true",
+	// set Wait if it was not passed as a flag
+	if o.Wait == nil {
+		if envOpts.Wait != nil {
+			o.Wait = envOpts.Wait
+		} else {
+			wait := false
+			o.Wait = &wait
+		}
 	}
 
-	return o
+	// set Headless if it was not passed as a flag
+	if o.Headless == nil {
+		if envOpts.Headless != nil {
+			o.Headless = envOpts.Headless
+		} else {
+			headless := false
+			o.Headless = &headless
+		}
+	}
 }

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,6 +20,7 @@
 * [ForEach](usage/foreach.md)
 * [Building a Bundle](usage/building-a-bundle.md)
 * [Deploying Atmo](usage/deploying-atmo.md)
+* [Headless Mode](usage/headless.md)
 
 ## Runnable API
 

--- a/docs/usage/headless.md
+++ b/docs/usage/headless.md
@@ -1,0 +1,38 @@
+# Atmo Headless Mode
+
+Atmo can be run 'headless' mode, which causes it to ignore the Directive and instead make each Runnable in your application available as an individual endpoint. This can be useful for a number of things such as automated testing (being able to test each Runnable in isolation with controlled inputs).
+
+Each function will be made available at a URI such as this:
+```
+POST /com.suborbital.test/default/get-file/v0.0.1
+```
+The format of this URL is: `/[identifier]/[namespace]/[name]/[appVersion]`. Your Directive defines the identifier and appVersion, and the namespace and name of each Runnable are listed in the `.runnable.yaml` file within each Runnable's directory.
+
+To define the inputs for the request, you can use the following:
+Desired input | Headless Request | Runnable API
+--- | --- | ---
+Request body | POST request body | `req::body()`
+Request state | `X-Atmo-State` header, formatted as JSON key/value pairs | `req::state(key)`
+URL parameters (such as /:name) | `X-Atmo-Params` header, formatted as JSON key/value pairs | `req::param(key)` 
+
+For example, if your Runnable expects data in the `user` [request state](../concepts/state.md) key, you would set the `X-Atmo-State` header as such:
+```
+{"user": "user@suborbital.dev"}
+```
+And if your Runnable expects to parse URL parameters such as `/api/:user`, you can use the `X-Atmo-Params` header in a similar fashion.
+
+## Running in Headless mode
+To run Atmo in headless mode, set the `ATMO_HEADLESS` env var:
+```
+ATMO_HEADLESS=true
+```
+
+In a Dockerfile, you can use the `ENV` command:
+```
+ENV ATMO_HEADLESS=true
+```
+
+Or with the Docker CLI:
+```
+docker run [...] -e ATMO_HEADLESS=true suborbital/atmo atmo
+```

--- a/example-project/Directive.yaml
+++ b/example-project/Directive.yaml
@@ -47,9 +47,9 @@ handlers:
           as: output
 
 # uncomment to try out scheduled jobs!
-# schedules:
-#   - name: run-every-10
-#     every:
-#       seconds: 30
-#     steps:
-#       - fn: log-it
+schedules:
+  - name: run-every-10
+    every:
+      seconds: 30
+    steps:
+      - fn: log-it

--- a/fqfn/fqfn.go
+++ b/fqfn/fqfn.go
@@ -64,6 +64,11 @@ func Parse(name string) FQFN {
 	return fqfn
 }
 
+// HeadlessURLPath returns the headless URL path for a function
+func (f FQFN) HeadlessURLPath() string {
+	return fmt.Sprintf("/%s/%s/%s/%s", f.Identifier, f.Namespace, f.Fn, f.Version)
+}
+
 func FromParts(ident, namespace, fn, version string) string {
 	return fmt.Sprintf("%s#%s::%s@%s", ident, namespace, fn, version)
 }

--- a/fqfn/fqfn.go
+++ b/fqfn/fqfn.go
@@ -1,0 +1,86 @@
+package fqfn
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+////////////////////////////////////////////////////////////////////
+// An FQFN (fully-qualified function name) is a 'globally unique'
+// name for a specific function from a specific application version
+// example: com.suborbital.test#default::get-file@v0.0.1
+// i.e. identifier # namespace :: name @ version
+////////////////////////////////////////////////////////////////////
+
+// NamespaceDefault and others represent conts for namespaces
+const (
+	NamespaceDefault = "default"
+)
+
+// FQFN is a parsed fqfn
+type FQFN struct {
+	Identifier string
+	Namespace  string
+	Fn         string
+	Version    string
+}
+
+func Parse(name string) FQFN {
+	// if the name contains a #, parse that out as the identifier
+	identifier := ""
+	identParts := strings.SplitN(name, "#", 2)
+	if len(identParts) == 2 {
+		identifier = identParts[0]
+		name = identParts[1]
+	}
+
+	// if a Runnable is referenced with its namespace, i.e. users#getUser
+	// then we need to parse that and ensure we only match that namespace
+
+	namespace := NamespaceDefault
+	namespaceParts := strings.SplitN(name, "::", 2)
+	if len(namespaceParts) == 2 {
+		namespace = namespaceParts[0]
+		name = namespaceParts[1]
+	}
+
+	// next, if the name contains an @, parse the app version
+	appVersion := ""
+	versionParts := strings.SplitN(name, "@", 2)
+	if len(versionParts) == 2 {
+		name = versionParts[0]
+		appVersion = versionParts[1]
+	}
+
+	fqfn := FQFN{
+		Identifier: identifier,
+		Namespace:  namespace,
+		Fn:         name,
+		Version:    appVersion,
+	}
+
+	return fqfn
+}
+
+func FromParts(ident, namespace, fn, version string) string {
+	return fmt.Sprintf("%s#%s::%s@%s", ident, namespace, fn, version)
+}
+
+func FromURL(u *url.URL) (string, error) {
+	path := u.Path
+	parts := strings.Split(path, "/")
+	if len(parts) != 4 {
+		return "", errors.New("path is not an FQFN")
+	}
+
+	ident := parts[0]
+	namespace := parts[1]
+	fn := parts[2]
+	version := parts[3]
+
+	fqfn := FromParts(ident, namespace, fn, version)
+
+	return fqfn, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -15,3 +15,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 )
+
+replace github.com/suborbital/vektor => /Users/cohix-so/Workspaces/suborbital/vektor

--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,8 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/suborbital/grav v0.3.2
 	github.com/suborbital/reactr v0.9.3-0.20210521151323-0a06b6e64358
-	github.com/suborbital/vektor v0.3.0
+	github.com/suborbital/vektor v0.4.1-0.20210528122244-4c6599246636
 	golang.org/x/mod v0.4.2
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 )
-
-replace github.com/suborbital/vektor => /Users/cohix-so/Workspaces/suborbital/vektor

--- a/go.sum
+++ b/go.sum
@@ -194,6 +194,8 @@ github.com/suborbital/vektor v0.2.3/go.mod h1:6YQE7r6t1JcVs3twpqjXDftsLUaTNUk5Yo
 github.com/suborbital/vektor v0.2.4/go.mod h1:uzSf3LuTDt7omkVgevQLGsGm6PuhWE7JF6zr+kw2PQs=
 github.com/suborbital/vektor v0.3.0 h1:GOeA2egNGqvj8ZSEkZkMJ1FuMohCZ0t4kzpxvLbfrBc=
 github.com/suborbital/vektor v0.3.0/go.mod h1:3xIK+UsDed8llTgfMs8aw7GvghYhmaQnCAC3b4Oslog=
+github.com/suborbital/vektor v0.4.1-0.20210528122244-4c6599246636 h1:M0y5S4z7o1XECNwYJYGxHwD8ponEt0E+jfcP3xd/jFg=
+github.com/suborbital/vektor v0.4.1-0.20210528122244-4c6599246636/go.mod h1:3xIK+UsDed8llTgfMs8aw7GvghYhmaQnCAC3b4Oslog=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/wasmerio/wasmer-go v1.0.3 h1:9pWIlIqUKxALvFlWK8+Zy90qyqxd+8wlyVG91txh1TU=

--- a/main.go
+++ b/main.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	waitFlag = "wait"
+	headlessFlag = "headless"
+	waitFlag     = "wait"
 )
 
 type atmoInfo struct {
@@ -48,14 +49,16 @@ Directive format and the powerful Runnable API using a variety of languages.`,
 			)
 
 			shouldWait := cmd.Flags().Changed(waitFlag)
+			shouldRunHeadless := cmd.Flags().Changed(headlessFlag)
 
-			server := atmo.New(
+			atmo := atmo.New(
 				options.UseLogger(logger),
 				options.UseBundlePath(path),
+				options.ShouldRunHeadless(shouldRunHeadless),
 				options.ShouldWait(shouldWait),
 			)
 
-			return server.Start()
+			return atmo.Start()
 		},
 	}
 

--- a/vendor/github.com/suborbital/vektor/vk/optionmodifiers.go
+++ b/vendor/github.com/suborbital/vektor/vk/optionmodifiers.go
@@ -1,6 +1,9 @@
 package vk
 
 import (
+	"crypto/tls"
+	"net/http"
+
 	"github.com/suborbital/vektor/vlog"
 )
 
@@ -11,6 +14,21 @@ type OptionsModifier func(*Options)
 func UseDomain(domain string) OptionsModifier {
 	return func(o *Options) {
 		o.Domain = domain
+	}
+}
+
+// UseTLSConfig sets a TLS config that will be used for HTTPS
+// This will take precedence over the Domain option in all cases
+func UseTLSConfig(config *tls.Config) OptionsModifier {
+	return func(o *Options) {
+		o.TLSConfig = config
+	}
+}
+
+// UseTLSPort sets the HTTPS port to be used:
+func UseTLSPort(port int) OptionsModifier {
+	return func(o *Options) {
+		o.TLSPort = port
 	}
 }
 
@@ -41,5 +59,15 @@ func UseAppName(name string) OptionsModifier {
 func UseEnvPrefix(prefix string) OptionsModifier {
 	return func(o *Options) {
 		o.EnvPrefix = prefix
+	}
+}
+
+// UseInspector sets a function that will be allowed to inspect every HTTP request
+// before it reaches VK's internal router, but cannot modify said request or affect
+// the handling of said request in any way. Use at your own risk, as it may introduce
+// performance issues if not used correctly.
+func UseInspector(isp func(http.Request)) OptionsModifier {
+	return func(o *Options) {
+		o.PreRouterInspector = isp
 	}
 }

--- a/vendor/github.com/suborbital/vektor/vk/options.go
+++ b/vendor/github.com/suborbital/vektor/vk/options.go
@@ -2,6 +2,8 @@ package vk
 
 import (
 	"context"
+	"crypto/tls"
+	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/sethvargo/go-envconfig"
@@ -10,11 +12,15 @@ import (
 
 // Options are the available options for Server
 type Options struct {
-	AppName   string `env:"_APP_NAME"`
-	Domain    string `env:"_DOMAIN"`
-	HTTPPort  int    `env:"_HTTP_PORT"`
-	EnvPrefix string `env:"-"`
-	Logger    *vlog.Logger
+	AppName   string       `env:"_APP_NAME"`
+	Domain    string       `env:"_DOMAIN"`
+	HTTPPort  int          `env:"_HTTP_PORT"`
+	TLSPort   int          `env:"_TLS_PORT"`
+	TLSConfig *tls.Config  `env:"-"`
+	EnvPrefix string       `env:"-"`
+	Logger    *vlog.Logger `env:"-"`
+
+	PreRouterInspector func(http.Request) `env:"-"`
 }
 
 func newOptsWithModifiers(mods ...OptionsModifier) *Options {
@@ -35,9 +41,9 @@ func newOptsWithModifiers(mods ...OptionsModifier) *Options {
 	return options
 }
 
-// ShouldUseTLS returns true if domain is set and TLS should be used
+// ShouldUseTLS returns true if domain is set and/or TLS is configured
 func (o *Options) ShouldUseTLS() bool {
-	return o.Domain != ""
+	return o.Domain != "" || o.TLSConfig != nil
 }
 
 // HTTPPortSet returns true if the HTTP port is set
@@ -54,6 +60,11 @@ func (o *Options) ShouldUseHTTP() bool {
 func (o *Options) finalize(prefix string) {
 	if o.Logger == nil {
 		o.Logger = vlog.Default(vlog.EnvPrefix(prefix))
+	}
+
+	// if no inspector was set, create an empty one
+	if o.PreRouterInspector == nil {
+		o.PreRouterInspector = func(_ http.Request) {}
 	}
 
 	envOpts := Options{}
@@ -76,5 +87,9 @@ func (o *Options) replaceFieldsIfNeeded(replacement *Options) {
 
 	if replacement.HTTPPort != 0 {
 		o.HTTPPort = replacement.HTTPPort
+	}
+
+	if replacement.TLSPort != 0 {
+		o.TLSPort = replacement.TLSPort
 	}
 }

--- a/vendor/github.com/suborbital/vektor/vk/server.go
+++ b/vendor/github.com/suborbital/vektor/vk/server.go
@@ -4,7 +4,10 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"sync"
+	"sync/atomic"
 
+	"github.com/julienschmidt/httprouter"
 	"golang.org/x/crypto/acme/autocert"
 )
 
@@ -12,7 +15,10 @@ const defaultEnvPrefix = "VK"
 
 // Server represents a vektor API server
 type Server struct {
-	*Router
+	router  *Router
+	lock    sync.RWMutex
+	started atomic.Value
+
 	server  *http.Server
 	options *Options
 }
@@ -21,23 +27,33 @@ type Server struct {
 func New(opts ...OptionsModifier) *Server {
 	options := newOptsWithModifiers(opts...)
 
-	router := routerWithOptions(options)
-
-	server := createGoServer(options, router)
+	router := NewRouter(options.Logger)
 
 	s := &Server{
-		Router:  router,
-		server:  server,
+		router:  router,
+		lock:    sync.RWMutex{},
+		started: atomic.Value{},
 		options: options,
 	}
+
+	s.started.Store(false)
+
+	// yes this creates a circular reference,
+	// but the VK server and HTTP server are
+	// extremely tightly wound together so
+	// we have to make this compromise
+	s.server = createGoServer(options, s)
 
 	return s
 }
 
 // Start starts the server listening
 func (s *Server) Start() error {
+	// lock the router modifiers (GET, POST etc.)
+	s.started.Store(true)
+
 	// mount the root set of routes before starting
-	s.mountGroup(s.Router.rootGroup())
+	s.router.Finalize()
 
 	if s.options.AppName != "" {
 		s.options.Logger.Info("starting", s.options.AppName, "...")
@@ -54,6 +70,138 @@ func (s *Server) Start() error {
 	return s.server.ListenAndServeTLS("", "")
 }
 
+// ServeHTTP serves HTTP requests using the internal router while allowing
+// said router to be swapped out underneath at any time in a thread-safe way
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// run the inspector with a dereferenced pointer
+	// so that it can view but not change said request
+	//
+	// we intentionally run this before the lock as it's
+	// possible the inspector may trigger a router-swap
+	// and that would cause a nasty deadlock
+	s.options.PreRouterInspector(*r)
+
+	// now lock to ensure the router isn't being swapped
+	// out from underneath us while we're serving this req
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	s.router.ServeHTTP(w, r)
+}
+
+// SwapRouter allows swapping VK's router out in realtime while
+// continuing to serve requests in the background
+func (s *Server) SwapRouter(router *Router) {
+	router.Finalize()
+
+	// lock after Finalizing the router so
+	// the lock is released as quickly as possible
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.router = router
+}
+
+// CanHandle returns true if the server can handle a given method and path
+func (s *Server) CanHandle(method, path string) bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return s.router.canHandle(method, path)
+}
+
+// GET is a shortcut for router.Handle(http.MethodGet, path, handle)
+func (s *Server) GET(path string, handler HandlerFunc) {
+	if s.started.Load().(bool) {
+		return
+	}
+
+	s.router.GET(path, handler)
+}
+
+// HEAD is a shortcut for router.Handle(http.MethodHead, path, handle)
+func (s *Server) HEAD(path string, handler HandlerFunc) {
+	if s.started.Load().(bool) {
+		return
+	}
+
+	s.router.HEAD(path, handler)
+}
+
+// OPTIONS is a shortcut for router.Handle(http.MethodOptions, path, handle)
+func (s *Server) OPTIONS(path string, handler HandlerFunc) {
+	if s.started.Load().(bool) {
+		return
+	}
+
+	s.router.OPTIONS(path, handler)
+}
+
+// POST is a shortcut for router.Handle(http.MethodPost, path, handle)
+func (s *Server) POST(path string, handler HandlerFunc) {
+	if s.started.Load().(bool) {
+		return
+	}
+
+	s.router.POST(path, handler)
+}
+
+// PUT is a shortcut for router.Handle(http.MethodPut, path, handle)
+func (s *Server) PUT(path string, handler HandlerFunc) {
+	if s.started.Load().(bool) {
+		return
+	}
+
+	s.router.PUT(path, handler)
+}
+
+// PATCH is a shortcut for router.Handle(http.MethodPatch, path, handle)
+func (s *Server) PATCH(path string, handler HandlerFunc) {
+	if s.started.Load().(bool) {
+		return
+	}
+
+	s.router.PATCH(path, handler)
+}
+
+// DELETE is a shortcut for router.Handle(http.MethodDelete, path, handle)
+func (s *Server) DELETE(path string, handler HandlerFunc) {
+	if s.started.Load().(bool) {
+		return
+	}
+
+	s.router.DELETE(path, handler)
+}
+
+// Handle adds a route to be handled
+func (s *Server) Handle(method, path string, handler HandlerFunc) {
+	if s.started.Load().(bool) {
+		return
+	}
+
+	s.router.Handle(method, path, handler)
+}
+
+// AddGroup adds a RouteGroup to be handled
+func (s *Server) AddGroup(group *RouteGroup) {
+	if s.started.Load().(bool) {
+		return
+	}
+
+	s.router.AddGroup(group)
+}
+
+// HandleHTTP allows vk to handle a standard http.HandlerFunc
+func (s *Server) HandleHTTP(method, path string, handler http.HandlerFunc) {
+	if s.started.Load().(bool) {
+		return
+	}
+
+	s.router.hrouter.Handle(method, path, func(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+		handler(w, r)
+	})
+}
+
 func createGoServer(options *Options, handler http.Handler) *http.Server {
 	if useHTTP := options.ShouldUseHTTP(); useHTTP {
 		return goHTTPServerWithPort(options, handler)
@@ -63,28 +211,41 @@ func createGoServer(options *Options, handler http.Handler) *http.Server {
 }
 
 func goTLSServerWithDomain(options *Options, handler http.Handler) *http.Server {
-	if options.Domain != "" {
+	if options.TLSConfig != nil {
+		options.Logger.Info("configured for HTTPS with custom configuration")
+	} else if options.Domain != "" {
 		options.Logger.Info("configured for HTTPS using domain", options.Domain)
 	}
 
-	m := &autocert.Manager{
-		Cache:      autocert.DirCache("~/.autocert"),
-		Prompt:     autocert.AcceptTOS,
-		HostPolicy: autocert.HostWhitelist(options.Domain),
+	tlsConfig := options.TLSConfig
+
+	if tlsConfig == nil {
+		m := &autocert.Manager{
+			Cache:      autocert.DirCache("~/.autocert"),
+			Prompt:     autocert.AcceptTOS,
+			HostPolicy: autocert.HostWhitelist(options.Domain),
+		}
+
+		addr := fmt.Sprintf(":%d", options.HTTPPort)
+		if options.HTTPPort == 0 {
+			addr = ":8080"
+		}
+
+		options.Logger.Info("serving TLS challenges on", addr)
+
+		go http.ListenAndServe(addr, m.HTTPHandler(nil))
+
+		tlsConfig = &tls.Config{GetCertificate: m.GetCertificate}
 	}
 
-	addr := fmt.Sprintf(":%d", options.HTTPPort)
-	if options.HTTPPort == 0 {
-		addr = ":8080"
+	addr := fmt.Sprintf(":%d", options.TLSPort)
+	if options.TLSPort == 0 {
+		addr = ":443"
 	}
-
-	options.Logger.Info("serving TLS challenges on", addr)
-
-	go http.ListenAndServe(addr, m.HTTPHandler(nil))
 
 	s := &http.Server{
-		Addr:      ":443",
-		TLSConfig: &tls.Config{GetCertificate: m.GetCertificate},
+		Addr:      addr,
+		TLSConfig: tlsConfig,
 		Handler:   handler,
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -27,7 +27,7 @@ github.com/suborbital/reactr/request
 github.com/suborbital/reactr/rt
 github.com/suborbital/reactr/rwasm
 github.com/suborbital/reactr/rwasm/moduleref
-# github.com/suborbital/vektor v0.3.0
+# github.com/suborbital/vektor v0.3.0 => /Users/cohix-so/Workspaces/suborbital/vektor
 ## explicit
 github.com/suborbital/vektor/vk
 github.com/suborbital/vektor/vlog
@@ -58,3 +58,4 @@ golang.org/x/text/unicode/norm
 # gopkg.in/yaml.v2 v2.4.0
 ## explicit
 gopkg.in/yaml.v2
+# github.com/suborbital/vektor => /Users/cohix-so/Workspaces/suborbital/vektor

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -27,7 +27,7 @@ github.com/suborbital/reactr/request
 github.com/suborbital/reactr/rt
 github.com/suborbital/reactr/rwasm
 github.com/suborbital/reactr/rwasm/moduleref
-# github.com/suborbital/vektor v0.3.0 => /Users/cohix-so/Workspaces/suborbital/vektor
+# github.com/suborbital/vektor v0.4.1-0.20210528122244-4c6599246636
 ## explicit
 github.com/suborbital/vektor/vk
 github.com/suborbital/vektor/vlog
@@ -58,4 +58,3 @@ golang.org/x/text/unicode/norm
 # gopkg.in/yaml.v2 v2.4.0
 ## explicit
 gopkg.in/yaml.v2
-# github.com/suborbital/vektor => /Users/cohix-so/Workspaces/suborbital/vektor


### PR DESCRIPTION
This implements 'headless' mode that causes Atmo to ignore the Directive and make each Runnable available at its own endpoint, using the FQFN as a URL.

Resolves #43 