### PR TITLE
Send messages before and after local function execution

### DIFF
--- a/atmo/coordinator/executor/executor.go
+++ b/atmo/coordinator/executor/executor.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/suborbital/atmo/bundle/load"
@@ -11,6 +12,7 @@ import (
 	"github.com/suborbital/grav/transport/websocket"
 	"github.com/suborbital/reactr/rcap"
 	"github.com/suborbital/reactr/rt"
+	"github.com/suborbital/vektor/vk"
 	"github.com/suborbital/vektor/vlog"
 )
 
@@ -24,6 +26,8 @@ var (
 type Executor struct {
 	reactr *rt.Reactr
 	grav   *grav.Grav
+
+	pod *grav.Pod
 
 	log *vlog.Logger
 
@@ -48,6 +52,7 @@ func New(log *vlog.Logger, transport *websocket.Transport) *Executor {
 	// Reactr is configured in UseCapabiltyConfig
 	e := &Executor{
 		grav:      g,
+		pod:       g.Connect(),
 		log:       log,
 		listening: sync.Map{},
 	}
@@ -56,7 +61,7 @@ func New(log *vlog.Logger, transport *websocket.Transport) *Executor {
 }
 
 // Do executes a local or remote job
-func (e *Executor) Do(jobType string, data interface{}) (interface{}, error) {
+func (e *Executor) Do(jobType string, data interface{}, ctx *vk.Ctx) (interface{}, error) {
 	if e.reactr == nil {
 		return nil, ErrExecutorNotConfigured
 	}
@@ -67,7 +72,18 @@ func (e *Executor) Do(jobType string, data interface{}) (interface{}, error) {
 		return nil, ErrCannotHandle
 	}
 
-	return e.reactr.Do(rt.NewJob(jobType, data)).Then()
+	res := e.reactr.Do(rt.NewJob(jobType, data))
+
+	e.pod.Send(grav.NewMsgWithParentID(fmt.Sprintf("local/%s", jobType), ctx.RequestID(), nil))
+
+	result, err := res.Then()
+	if err != nil {
+		e.pod.Send(grav.NewMsgWithParentID(rt.MsgTypeReactrRunErr, ctx.RequestID(), []byte(err.Error())))
+	} else {
+		e.pod.Send(grav.NewMsgWithParentID(rt.MsgTypeReactrResult, ctx.RequestID(), []byte(result.([]byte))))
+	}
+
+	return result, err
 }
 
 // UseCapabilityConfig sets up the executor's Reactr instance using the provided capability configuration

--- a/atmo/coordinator/executor/executor.go
+++ b/atmo/coordinator/executor/executor.go
@@ -80,7 +80,7 @@ func (e *Executor) Do(jobType string, data interface{}, ctx *vk.Ctx) (interface{
 	if err != nil {
 		e.pod.Send(grav.NewMsgWithParentID(rt.MsgTypeReactrRunErr, ctx.RequestID(), []byte(err.Error())))
 	} else {
-		e.pod.Send(grav.NewMsgWithParentID(rt.MsgTypeReactrResult, ctx.RequestID(), []byte(result.([]byte))))
+		e.pod.Send(grav.NewMsgWithParentID(rt.MsgTypeReactrResult, ctx.RequestID(), result.([]byte)))
 	}
 
 	return result, err

--- a/atmo/coordinator/sequence.go
+++ b/atmo/coordinator/sequence.go
@@ -13,8 +13,6 @@ import (
 	"github.com/suborbital/vektor/vlog"
 )
 
-type runFunc func(jobType string, data interface{}) *rt.Result
-
 // ErrSequenceRunErr is returned when the sequence returned due to a Runnable's RunErr
 var ErrSequenceRunErr = errors.New("sequence resulted in a RunErr")
 

--- a/atmo/coordinator/sequence_single.go
+++ b/atmo/coordinator/sequence_single.go
@@ -26,7 +26,7 @@ func (seq sequence) runSingleFn(fn directive.CallableFn, reqJSON []byte) (*fnRes
 	var runErr *rt.RunErr
 
 	// Do will execute the job locally if possible or find a remote peer to execute it
-	res, err := seq.exec.Do(fn.FQFN, reqJSON)
+	res, err := seq.exec.Do(fn.FQFN, reqJSON, seq.ctx)
 	if err != nil {
 		// check if the error type is rt.RunErr, because those are handled differently
 		returnedErr := &rt.RunErr{}


### PR DESCRIPTION
Previously to the `autoscaling` work, all function executions happened through Atmo's internal Grav message bus. This was found to be less performant than just calling the Reactr instance directly instead (somewhat obvious in retrospect)

The autoscaling work added the `Executor` type, which is a facade over the two methods of executing a function (locally, by calling Reactr directly, or remotely by sending a message over the Grav bus), so that the most appropriate method would always be used.

This meant that functions executed on the local Reactr instance directly no longer had messages sent over the Grav bus to, for example, let a configured control-plane know that something had been executed.

This PR adds message sending back into the fray to restore the old functionality while still getting the performance improvements of executing Reactr directly.