### PR TITLE
Only run headless auth on Runnable endpoints

### DIFF
--- a/atmo/appsource/bundlesource.go
+++ b/atmo/appsource/bundlesource.go
@@ -57,12 +57,6 @@ func (b *BundleSource) Runnables() []directive.Runnable {
 // FindRunnable searches for and returns the requested runnable
 // otherwise ErrRunnableNotFound
 func (b *BundleSource) FindRunnable(fqfn, auth string) (*directive.Runnable, error) {
-	// refresh the bundle since it's possible it was updated underneath you
-	// this full-locks, so we call it before the RLock
-	if err := b.findBundle(); err != nil {
-		return nil, ErrRunnableNotFound
-	}
-
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 

--- a/atmo/coordinator/coordinator_headlessauth.go
+++ b/atmo/coordinator/coordinator_headlessauth.go
@@ -14,8 +14,8 @@ func (c *Coordinator) headlessAuthMiddleware() vk.Middleware {
 	return func(r *http.Request, ctx *vk.Ctx) error {
 		FQFN, err := fqfn.FromURL(r.URL)
 		if err != nil {
-			ctx.Log.Error(errors.Wrap(err, "failed to fqfn.FromURL"))
-			return vk.E(http.StatusBadRequest, "invalid FQFN URI")
+			ctx.Log.Debug(errors.Wrap(err, "failed to fqfn.FromURL, skipping headless auth"))
+			return nil
 		}
 
 		auth := r.Header.Get("Authorization")


### PR DESCRIPTION
This PR modifies the headless auth middleware to skip auth if the request URL in question is not an FQFN, which in headless mode includes `/meta/metrics` and `/health`. All Runnables are accessed by full FQFN URL, so auth will continue to run on those requests.