### PR TITLE
feat(proxy): global environment token

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -26,6 +26,11 @@ jobs:
       run: |
         go get -v -t -d ./...
         go mod vendor
+
+    - name: Build
+      run: |
+        make atmo
+        make atmo/proxy
       
     - name: Run test
       run: |

--- a/atmo/atmo.go
+++ b/atmo/atmo.go
@@ -114,6 +114,11 @@ func (a *Atmo) inspectRequest(r http.Request) {
 		// the Authorization header is passed through to the AppSource, and can be used to authenticate calls.
 		auth := r.Header.Get("Authorization")
 
+		// if in proxy mode, use the configured global env token for all requests (if available)
+		if a.options.Proxy && a.options.EnvironmentToken != "" {
+			auth = a.options.EnvironmentToken
+		}
+
 		if _, err := a.coordinator.App.FindRunnable(FQFN, auth); err != nil {
 			a.options.Logger.Debug(errors.Wrapf(err, "failed to FindRunnable %s, request will proceed and fail", FQFN).Error())
 			return

--- a/atmo/coordinator/coordinator.go
+++ b/atmo/coordinator/coordinator.go
@@ -188,7 +188,9 @@ func (c *Coordinator) SetSchedules() {
 			// create basically an fqfn for this schedule (com.suborbital.appname#schedule.dojob@v0.1.0).
 			jobName := fmt.Sprintf("%s#schedule.%s@%s", application.Identifier, s.Name, application.AppVersion)
 
-			c.exec.Register(jobName, &scheduledRunner{rtFunc})
+			capConfig := rcap.DefaultCapabilityConfig()
+
+			c.exec.Register(jobName, &scheduledRunner{rtFunc}, &capConfig)
 
 			seconds := s.NumberOfSeconds()
 

--- a/atmo/coordinator/coordinator_headlessauth.go
+++ b/atmo/coordinator/coordinator_headlessauth.go
@@ -13,6 +13,10 @@ import (
 
 func (c *Coordinator) headlessAuthMiddleware() vk.Middleware {
 	return func(r *http.Request, ctx *vk.Ctx) error {
+		if c.opts.Proxy && c.opts.EnvironmentToken != "" {
+			return nil
+		}
+
 		FQFN, err := fqfn.FromURL(r.URL)
 		if err != nil {
 			ctx.Log.Debug(errors.Wrap(err, "failed to fqfn.FromURL, skipping headless auth"))

--- a/atmo/coordinator/executor/executor.go
+++ b/atmo/coordinator/executor/executor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/suborbital/grav/discovery/local"
 	"github.com/suborbital/grav/grav"
 	"github.com/suborbital/grav/transport/websocket"
+	"github.com/suborbital/reactr/rcap"
 	"github.com/suborbital/reactr/request"
 	"github.com/suborbital/reactr/rt"
 	"github.com/suborbital/reactr/rwasm"
@@ -114,12 +115,17 @@ func (e *Executor) UseGrav(g *grav.Grav) {
 }
 
 // Register registers a Runnable.
-func (e *Executor) Register(jobType string, runner rt.Runnable, opts ...rt.Option) error {
+func (e *Executor) Register(jobType string, runner rt.Runnable, capConfig *rcap.CapabilityConfig, opts ...rt.Option) error {
 	if e.reactr == nil {
 		return ErrExecutorNotConfigured
 	}
 
-	e.reactr.Register(jobType, runner, opts...)
+	caps, err := rt.CapabilitiesFromConfig(*capConfig)
+	if err != nil {
+		return errors.Wrap(err, "failed to CapabilitiesFromConfig")
+	}
+
+	e.reactr.RegisterWithCaps(jobType, runner, *caps, opts...)
 
 	return nil
 }

--- a/atmo/coordinator/executor/executor_proxy.go
+++ b/atmo/coordinator/executor/executor_proxy.go
@@ -184,7 +184,7 @@ func (e *Executor) UseCapabilityConfig(config rcap.CapabilityConfig) error {
 }
 
 // Register registers a Runnable
-func (e *Executor) Register(jobType string, runner rt.Runnable, opts ...rt.Option) error {
+func (e *Executor) Register(jobType string, runner rt.Runnable, capConfig *rcap.CapabilityConfig, opts ...rt.Option) error {
 	// nothing to do in proxy mode
 
 	return nil

--- a/atmo/options/options.go
+++ b/atmo/options/options.go
@@ -13,13 +13,14 @@ const atmoEnvPrefix = "ATMO"
 
 // Options defines options for Atmo.
 type Options struct {
-	Logger       *vlog.Logger
-	BundlePath   string `env:"ATMO_BUNDLE_PATH"`
-	RunSchedules *bool  `env:"ATMO_RUN_SCHEDULES,default=true"`
-	Headless     *bool  `env:"ATMO_HEADLESS,default=false"`
-	Wait         *bool  `env:"ATMO_WAIT,default=false"`
-	ControlPlane string `env:"ATMO_CONTROL_PLANE"`
-	Proxy        bool
+	Logger           *vlog.Logger
+	BundlePath       string `env:"ATMO_BUNDLE_PATH"`
+	RunSchedules     *bool  `env:"ATMO_RUN_SCHEDULES,default=true"`
+	Headless         *bool  `env:"ATMO_HEADLESS,default=false"`
+	Wait             *bool  `env:"ATMO_WAIT,default=false"`
+	ControlPlane     string `env:"ATMO_CONTROL_PLANE"`
+	EnvironmentToken string `env:"ATMO_ENV_TOKEN"`
+	Proxy            bool
 }
 
 // Modifier defines options for Atmo.
@@ -113,4 +114,11 @@ func (o *Options) finalize(prefix string) {
 
 	// compile-time decision about enabling proxy mode.
 	o.Proxy = proxyEnabled()
+
+	// only set the env token in config if we're in proxy mode
+	if o.Proxy {
+		o.EnvironmentToken = envOpts.EnvironmentToken
+	} else {
+		o.EnvironmentToken = ""
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/suborbital/grav v0.5.0
 	github.com/suborbital/reactr v0.15.0
-	github.com/suborbital/vektor v0.5.2
+	github.com/suborbital/vektor v0.5.3-0.20220222201553-80b210187e79
 	golang.org/x/mod v0.5.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -402,8 +402,8 @@ github.com/suborbital/reactr v0.15.0/go.mod h1:j1zFdG5hpZwJlIBLrScTlXxn9WZoq0rhW
 github.com/suborbital/vektor v0.2.2/go.mod h1:6YQE7r6t1JcVs3twpqjXDftsLUaTNUk5YorRKHcDamI=
 github.com/suborbital/vektor v0.5.1-0.20211112160641-0b7e68b46795/go.mod h1:116rovoAiwxaOzrTf849x54mlaec41qvB1d/9UeA+xk=
 github.com/suborbital/vektor v0.5.1/go.mod h1:116rovoAiwxaOzrTf849x54mlaec41qvB1d/9UeA+xk=
-github.com/suborbital/vektor v0.5.2 h1:WjzNBKfHtbpefnc+GLNlkRsXQrRblkgaTEZS34mc8VY=
-github.com/suborbital/vektor v0.5.2/go.mod h1:116rovoAiwxaOzrTf849x54mlaec41qvB1d/9UeA+xk=
+github.com/suborbital/vektor v0.5.3-0.20220222201553-80b210187e79 h1:8DYmzqXB8zxVAzlLZdSL/a7z35N8CNp4ipn5sVI5HfY=
+github.com/suborbital/vektor v0.5.3-0.20220222201553-80b210187e79/go.mod h1:116rovoAiwxaOzrTf849x54mlaec41qvB1d/9UeA+xk=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/twmb/franz-go v1.2.6 h1:WVub2Sml7LqER9VU0WxsiOTom4LBK7YMj+7jbqadE3U=
 github.com/twmb/franz-go v1.2.6/go.mod h1:P+i2DnBaec1o0z9EI8CyAM/WAjG99CHI3oCAhZDoy48=


### PR DESCRIPTION
This allows a 'global' env token to be set when Atmo is in proxy mode. This allows atmo-proxy to authenticate the `FundRunnable` call to the control plane for all requests.

This PR also exposes capability configs on the executor and adds a build step to CI to ensure proxy mode can always be built.