### PR TITLE
Add goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.17'
+
+      - name: Cache Go mods
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Get dependencies
+        run: |
+          go mod download
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -2,9 +2,9 @@ name: Testapalooza
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   pull_request:
-    branches: [ "*" ]
 
 jobs:
 
@@ -24,14 +24,13 @@ jobs:
 
     - name: Get dependencies
       run: |
-        go get -v -t -d ./...
-        go mod vendor
+        go mod download
 
     - name: Build
       run: |
         make atmo
         make atmo/proxy
-      
+
     - name: Run test
       run: |
         make build

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,35 @@
+builds:
+  - <<: &build_defaults
+      id: atmo
+      main: .
+      binary: atmo
+      env:
+        - CGO_ENABLED=1
+      goos:
+        - linux
+        - darwin
+      goarch:
+        - amd64
+        - arm64
+      ldflags:
+        - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+  - <<: *build_defaults
+    id: atmo-proxy
+    binary: atmo-proxy
+    tags: proxy
+
+changelog:
+  skip: true
+
+checksum:
+  name_template: 'checksums.txt'
+
+archives:
+  - id: atmo-archive
+    name_template: 'atmo-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
+    builds:
+      - atmo
+  - id: atmo-proxy-archive
+    name_template: 'atmo-proxy-v{{ .Version }}-{{ .Os }}-{{ .Arch }}'
+    builds:
+      - atmo-proxy


### PR DESCRIPTION
Adds release workflow that runs GoReleaser, creating archives for atmo
and atmo-proxy on tagged releases.
