### PR TITLE
feat(coordinator): ability to define static peers for Grav connection

### DIFF
--- a/atmo/coordinator/coordinator.go
+++ b/atmo/coordinator/coordinator.go
@@ -62,7 +62,7 @@ func New(appSource appsource.AppSource, options *options.Options) *Coordinator {
 		transport = websocket.New()
 	}
 
-	exec := executor.New(options.Logger, transport)
+	exec := executor.New(options.Logger, transport, options)
 
 	c := &Coordinator{
 		App:         appSource,

--- a/atmo/coordinator/executor/executor.go
+++ b/atmo/coordinator/executor/executor.go
@@ -58,17 +58,17 @@ func New(log *vlog.Logger, transport *websocket.Transport, opts *options.Options
 
 	g := grav.New(gravOpts...)
 
-	go connectStaticPeers(log, g, opts)
-
-	return NewWithGrav(log, g)
+	return NewWithGrav(log, g, opts)
 }
 
 // NewWithGrav creates an Executor with a custom Grav instance.
-func NewWithGrav(log *vlog.Logger, g *grav.Grav) *Executor {
+func NewWithGrav(log *vlog.Logger, g *grav.Grav, opts *options.Options) *Executor {
 	var pod *grav.Pod
 
 	if g != nil {
 		pod = g.Connect()
+
+		go connectStaticPeers(log, g, opts)
 	}
 
 	e := &Executor{

--- a/atmo/coordinator/executor/executor_proxy.go
+++ b/atmo/coordinator/executor/executor_proxy.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/suborbital/atmo/atmo/appsource"
+	"github.com/suborbital/atmo/atmo/options"
 	"github.com/suborbital/atmo/directive/executable"
 	"github.com/suborbital/grav/discovery/local"
 	"github.com/suborbital/grav/grav"
@@ -43,7 +44,7 @@ type Executor struct {
 }
 
 // New creates a new Executor
-func New(log *vlog.Logger, transport *websocket.Transport) *Executor {
+func New(log *vlog.Logger, transport *websocket.Transport, _ *options.Options) *Executor {
 	gravOpts := []grav.OptionsModifier{
 		grav.UseLogger(log),
 	}

--- a/atmo/options/options.go
+++ b/atmo/options/options.go
@@ -20,6 +20,7 @@ type Options struct {
 	Wait             *bool  `env:"ATMO_WAIT,default=false"`
 	ControlPlane     string `env:"ATMO_CONTROL_PLANE"`
 	EnvironmentToken string `env:"ATMO_ENV_TOKEN"`
+	StaticPeers      string `env:"ATMO_PEERS"`
 	Proxy            bool
 	TracerConfig     TracerConfig `env:",prefix=ATMO_TRACER_"`
 }
@@ -140,6 +141,7 @@ func (o *Options) finalize(prefix string) {
 
 	o.EnvironmentToken = ""
 	o.TracerConfig = TracerConfig{}
+	o.StaticPeers = envOpts.StaticPeers
 
 	// compile-time decision about enabling proxy mode.
 	o.Proxy = proxyEnabled()


### PR DESCRIPTION
This PR allows the user to set `ATMO_PEERS` to "force" Grav connections to specific peers.

 Discovery is also still enabled, and will create connections in addition to the static peers