### PR TITLE
fix(streams): update Grav and use consistent UUID for stream handlers

### DIFF
--- a/atmo/coordinator/coordinator_stream.go
+++ b/atmo/coordinator/coordinator_stream.go
@@ -3,7 +3,6 @@ package coordinator
 import (
 	"fmt"
 
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
 	"github.com/suborbital/atmo/atmo/appsource"
@@ -61,7 +60,7 @@ func (c *Coordinator) streamConnectionForDirectiveHandler(handler directive.Hand
 		req := &request.CoordinatedRequest{
 			Method:      atmoMethodStream,
 			URL:         handler.Input.Resource,
-			ID:          uuid.New().String(),
+			ID:          ctx.RequestID(),
 			Body:        msg.Data(),
 			Headers:     map[string]string{},
 			RespHeaders: map[string]string{},
@@ -91,7 +90,7 @@ func (c *Coordinator) streamConnectionForDirectiveHandler(handler directive.Hand
 			replyTopic = handler.RespondTo
 		}
 
-		pod.ReplyTo(msg, grav.NewMsg(replyTopic, result))
+		pod.ReplyTo(msg, grav.NewMsgWithParentID(replyTopic, ctx.RequestID(), result))
 
 		return nil
 	})

--- a/atmo/coordinator/executor/executor.go
+++ b/atmo/coordinator/executor/executor.go
@@ -263,6 +263,10 @@ func (e *Executor) Metrics() (*rt.ScalerMetrics, error) {
 }
 
 func connectStaticPeers(log *vlog.Logger, g *grav.Grav, opts *options.Options) {
+	if strings.TrimSpace(opts.StaticPeers) == "" {
+		return
+	}
+
 	epts := strings.Split(opts.StaticPeers, ",")
 
 	for _, e := range epts {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-envconfig v0.5.0
 	github.com/spf13/cobra v1.2.1
-	github.com/suborbital/grav v0.5.1-0.20220314153349-3932e8bdc3f0
+	github.com/suborbital/grav v0.5.1-0.20220401153127-41df567a4501
 	github.com/suborbital/reactr v0.15.1
 	github.com/suborbital/vektor v0.5.3-0.20220302142328-fb4fc3951eb1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -409,6 +409,10 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/suborbital/grav v0.5.0/go.mod h1:cul5DpYVRAmoUxaqzaKYOpoFCFb9LpzQiCrre2DP0Sg=
 github.com/suborbital/grav v0.5.1-0.20220314153349-3932e8bdc3f0 h1:UtjIpXx7WIfv9N6woopVsuP/pjJAwNTv2l76euNru/A=
 github.com/suborbital/grav v0.5.1-0.20220314153349-3932e8bdc3f0/go.mod h1:c0Jbycyryjz4RMtiENnvAT8J9yIMGSPt3GpyQJt1TH8=
+github.com/suborbital/grav v0.5.1-0.20220401143451-09bfb5fca5ee h1:CvIttAPDmVO7Mz1hlFRcGVmAGhmJWPosqACmr4i7DpU=
+github.com/suborbital/grav v0.5.1-0.20220401143451-09bfb5fca5ee/go.mod h1:c0Jbycyryjz4RMtiENnvAT8J9yIMGSPt3GpyQJt1TH8=
+github.com/suborbital/grav v0.5.1-0.20220401153127-41df567a4501 h1:PEiRGQPYCILVPR5zqi+Ljo9v5NjVIj9vPxQz8m2Neno=
+github.com/suborbital/grav v0.5.1-0.20220401153127-41df567a4501/go.mod h1:c0Jbycyryjz4RMtiENnvAT8J9yIMGSPt3GpyQJt1TH8=
 github.com/suborbital/reactr v0.15.1 h1:IJNsh9SiXHp2B4wpTSMseIym4XvAYP7N5fQSADfGwbM=
 github.com/suborbital/reactr v0.15.1/go.mod h1:JC+km01xHNSuQDYsxWCBBh7fJrctI1Yai7Mm/Ws3xAU=
 github.com/suborbital/vektor v0.5.1/go.mod h1:116rovoAiwxaOzrTf849x54mlaec41qvB1d/9UeA+xk=


### PR DESCRIPTION
This updates Grav such that non-`message` formatted messages can be read off a stream without issue. It also ensures a consistent UUID is used for the message handling.

This PR also adds an early exit to `ConnectStaticPeers` which would cause an attempt to connect to a peer when none were configured, adding logging noise.