### PR TITLE
fix(coordinator): Update connections check to check version instead of namespace

### DIFF
--- a/atmo/coordinator/capabilities/capabilities.go
+++ b/atmo/coordinator/capabilities/capabilities.go
@@ -18,7 +18,7 @@ func ResolveFromSource(source appsource.AppSource, ident, namespace, version str
 		return defaultConfig, nil
 	}
 
-	connections := source.Connections(ident, namespace)
+	connections := source.Connections(ident, version)
 
 	if userConfig.Logger != nil {
 		defaultConfig.Logger = userConfig.Logger
@@ -67,7 +67,8 @@ func ResolveFromSource(source appsource.AppSource, ident, namespace, version str
 		defaultConfig.File = userConfig.File
 	}
 
-	if userConfig.DB != nil {
+	// Override the connections.Database struct
+	if userConfig.DB.Enabled {
 		defaultConfig.DB = userConfig.DB
 	}
 

--- a/atmo/coordinator/capabilities/capabilities.go
+++ b/atmo/coordinator/capabilities/capabilities.go
@@ -68,7 +68,7 @@ func ResolveFromSource(source appsource.AppSource, ident, namespace, version str
 	}
 
 	// Override the connections.Database struct
-	if userConfig.DB.Enabled {
+	if userConfig.DB != nil && userConfig.DB.Enabled {
 		defaultConfig.DB = userConfig.DB
 	}
 


### PR DESCRIPTION
The check for database connections was comparing the ident and the namespace to the ident and version,
which can never be true.

Also related to this bug, the `userConfig` defined in capabilities from reactr is always defined by default.
As such, the check for `userConfig.DB != nil` always evaluated to true, overwriting the database defined
in connections.

Fixes: #166