### PR TITLE
fix(coordinator): prevent panic due to function re-registration

### DIFF
--- a/atmo/coordinator/executor/executor.go
+++ b/atmo/coordinator/executor/executor.go
@@ -217,6 +217,11 @@ func (e *Executor) Load(source appsource.AppSource) error {
 				continue
 			}
 
+			// since a Runnable at a given version is meant to be immutable, don't try to register it again
+			if e.reactr.IsRegistered(fn.FQFN) {
+				continue
+			}
+
 			e.reactr.RegisterWithCaps(fn.FQFN, rwasm.NewRunnerWithRef(fn.ModuleRef), *capObject)
 
 			e.log.Debug("adding listener for", fn.FQFN)


### PR DESCRIPTION
If a particular function gets duplicated and Atmo is running in Headless mode, the double-registration on the server causes a panic. This prevents such panics by tracking the exact handlers added to the server, and skip any duplicates.