### PR TITLE
chore(errors): Add returned error as an internal error when plugin execution errors

### DIFF
--- a/e2core/server/handlers.go
+++ b/e2core/server/handlers.go
@@ -106,7 +106,7 @@ func (s *Server) executePluginByRefHandler(l zerolog.Logger) echo.HandlerFunc {
 		}
 
 		if err := s.dispatcher.Execute(seq); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to execute plugin")
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to execute plugin").SetInternal(err)
 		}
 
 		// handle any response headers that were set by the Runnables.


### PR DESCRIPTION
No issue.

There was one path where executing a plugin did not add the returned error to the response, so the error handler could print it for us.

e2core ate those errors. I'd like to see them.